### PR TITLE
validus: fix denial when setting user profile picture

### DIFF
--- a/sepolicy/priv_app.te
+++ b/sepolicy/priv_app.te
@@ -1,0 +1,1 @@
+allow priv_app system_app_data_file:file write;


### PR DESCRIPTION
 * This allows the default Gallery app to set the user profile picture

[298887.878199] type=1400 audit(1500699998.019:640): avc: denied { write } for pid=6660 comm="Binder:6647_1" path="/data/user_de/0/com.android.settings/cache/CropEditUserPhoto.jpg" dev="sda15" ino=1866326 scontext=u:r:priv_app:s0:c512,c768 tcontext=u:object_r:system_app_data_file:s0 tclass=file permissive=0
[298887.910918] type=1400 audit(1500699998.049:641): avc: denied { write } for pid=15001 comm="Binder:6647_5" path="/data/user_de/0/com.android.settings/cache/CropEditUserPhoto.jpg" dev="sda15" ino=1866326 scontext=u:r:priv_app:s0:c512,c768 tcontext=u:object_r:system_app_data_file:s0 tclass=file permissive=0

Change-Id: Ia416e69b561c2b656d00ed401abd4d7d67bfc0d4
Signed-off-by: Raleigh Matlock <raleighman2@gmail.com>